### PR TITLE
Add integration-test to verify PAY button before and after user inputs on TransactionCreateStepTwo

### DIFF
--- a/src/tests/integration-tests/TransactionCreate.test.js
+++ b/src/tests/integration-tests/TransactionCreate.test.js
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import TransactionCreateStepTwo from "components/TransactionCreateStepTwo";
+
+/**
+ * Integration tests is a way of testing multiple components interaction at once.
+ * For example, here we are testing the user flow of creating a Transaction by
+ * 1. Asserting the PAY button should be disabled on first startup of the Transaction Create form.
+ * 2. Asserting that the PAY button be enabled once amount and note are filled in.
+ */
+test("Verify the PAY button before and after amount & note are filled in.", async () => {
+  // Arrange: Rendering the component to be tested.
+  render(<TransactionCreateStepTwo sender={{ id: "5" }} receiver={{ id: "5" }} />);
+
+  // Assertion 1: Before the amount and note are filled in, PAY button should be disabled.
+  expect(await screen.findByRole("button", { name: /pay/i })).toBeDisabled();
+
+  // Action: User inputs amount
+  userEvent.type(screen.getByPlaceholderText(/amount/i), "50");
+
+  // Action: User inputs note
+  userEvent.type(screen.getByPlaceholderText(/add a note/i), "Test PAY button activated.");
+
+  // Assertion 2: After the amount and note are filled in, PAY button should be enabled.
+  expect(await screen.findByRole("button", { name: /pay/i })).toBeEnabled();
+});


### PR DESCRIPTION
### Description

- Create an integration-test folder under src/integration-tests/TransactionCreate.test.js
- Add integration-test which includes a user flow of:
   1. Render the component of TransactionCreateStepTwo
   2. Assert the PAY button is disabled at the start
   3. Enter $ amount
   4. Enter note
   5. Assert the PAY button is enabled now as $ and note are entered.

All tests (unit and integration tests) run: PASSED ✅  

<img width="442" alt="Screen Shot 2022-08-14 at 9 21 33 PM" src="https://user-images.githubusercontent.com/31334333/184539259-241646f3-c3ee-40e4-b34f-2874a9fdfc65.png">
